### PR TITLE
[POL-46] FIX : add response userStoryCnt, userPieceCnt

### DIFF
--- a/src/main/java/com/umc/pol/domain/story/controller/StoryController.java
+++ b/src/main/java/com/umc/pol/domain/story/controller/StoryController.java
@@ -130,10 +130,10 @@ public class StoryController {
 
   @Operation(summary = "이야기 필터링", description = "자신이 쓴 이야기를 tagId를 기준으로 필터링합니다. [요청할 때마다 page를 1씩 증가시키면서 호출]")
   @GetMapping("/filter/{tagId}")
-  public ListResponse<ResponseStoryFilterDto> filteringStory(@PathVariable long tagId, Pageable pageable, HttpServletRequest request) {
+  public SingleResponse<StoryCountDto> filteringStory(@PathVariable long tagId, Pageable pageable, HttpServletRequest request) {
 
 
-    return responseService.getListResponse(storyService.getFilterStoryPage(request, tagId, pageable));
+    return responseService.getSingleResponse(storyService.getFilterStoryPage(request, tagId, pageable));
   }
 
   @Operation(summary = "이야기 좋아요", description = "이야기에 좋아요를 남깁니다. (토큰 설정 전까지 userId를 RequestParam으로 받음.)")

--- a/src/main/java/com/umc/pol/domain/story/dto/StoryCountDto.java
+++ b/src/main/java/com/umc/pol/domain/story/dto/StoryCountDto.java
@@ -1,0 +1,20 @@
+package com.umc.pol.domain.story.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class StoryCountDto {
+    private int userStoryCnt;
+    private int userPieceCnt;
+    private List<ResponseStoryFilterDto> storyTags;
+
+    @Builder
+    public StoryCountDto(int userStoryCnt, int userPieceCnt, List<ResponseStoryFilterDto> storyTags) {
+        this.userStoryCnt = userStoryCnt;
+        this.userPieceCnt = userPieceCnt;
+        this.storyTags = storyTags;
+    }
+}

--- a/src/main/java/com/umc/pol/domain/story/repository/QnaRepository.java
+++ b/src/main/java/com/umc/pol/domain/story/repository/QnaRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 @Repository
 public interface QnaRepository extends JpaRepository<Qna, Long> {
     List<Qna> findAllByStory(Story story);
+
+    int countByStory(Story data);
 }

--- a/src/main/java/com/umc/pol/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/umc/pol/domain/story/repository/StoryRepository.java
@@ -2,6 +2,8 @@ package com.umc.pol.domain.story.repository;
 
 import com.umc.pol.domain.story.entity.Story;
 import com.umc.pol.domain.user.entity.User;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StoryRepository extends JpaRepository<Story, Long>, StoryRepositoryCustom {
   Optional<Story> findStoryByUserAndAndId(User user, Long id);
+
+  List<Story> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/umc/pol/domain/story/service/StoryService.java
+++ b/src/main/java/com/umc/pol/domain/story/service/StoryService.java
@@ -207,7 +207,8 @@ public class StoryService {
     }
 
     // tagId 기준 이야기  필터링
-    public List<ResponseStoryFilterDto> getFilterStoryPage(HttpServletRequest request, long tagId, Pageable pageable) {
+//    public List<ResponseStoryFilterDto> getFilterStoryPage(HttpServletRequest request, long tagId, Pageable pageable) {
+    public StoryCountDto getFilterStoryPage(HttpServletRequest request, long tagId, Pageable pageable) {
         Long userId = (Long) request.getAttribute("id");
         List<String> setContents = new ArrayList<>();
         // story의 storyTag.Content를 List로 만들기
@@ -224,6 +225,7 @@ public class StoryService {
         setContents = contents.stream().distinct().collect(Collectors.toList());
 
 
+
         // content를 기준으로 story 묶기
         setContents.forEach(content -> dtos.add(ResponseStoryFilterDto.builder()
                                                                     .storyTag(content)
@@ -234,7 +236,14 @@ public class StoryService {
                                                                     .build())
         );
 
-        return dtos;
+        List<Story> allStories = storyRepository.findAllByUserId(userId);
+
+        return StoryCountDto.builder()
+                .userStoryCnt(allStories.size())
+                .userPieceCnt(allStories.stream().mapToInt(qnaRepository::countByStory).sum())
+                .storyTags(dtos)
+                .build();
+
     }
 
     @Transactional


### PR DESCRIPTION
## 📝 PR Summary
<!-- PR 한줄 요약 -->
Response에 userStoryCnt와 userPieceCnt 추가

#### 🌲 Working Branch
<!-- 작업 브랜치 이름 -->
fix/POL-46-story-filter

#### ✅ TODOs
<!-- PR 작업한 내용 -->
- [x] Response를 storyTag 별로 분류된 story를 가진 List -> 기존의 List와 userStoryCnt, userPieceCnt를 가진 SingleResponse로 교체
- [x] userStoryCnt는 story 테이블에서 userId와 일치하는 모든 story를 찾아 List의 크기로 적용
- [x] userPieceCnt는 userId와 일치하는 모든 story를 찾아 Qna 테이블에서 stroyId와 일치하는 Qna의 개수로 적용

#### 📚 Remarks
<!-- 기능 개발 비고사항 -->
